### PR TITLE
Storage account with restricted public access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,84 @@
-# terraform-module-template
-When you use this template it will add a basic main, variable and output file and a Readme.md file.
+# Terraform Module: for Storage account with restricted public access
 
-when you come to name your project I would suggest prefixing with `tfmodule-[Azure|AWS]-description-of-service`
+This module can be used to create a storage account that is configured to restrict public 
+
+## Required Resources
+
+- `Resource Group` exists or is created external to the module.
+- `Provider` must be created external to the module.
+
+## Usage
+
+```terraform
+variable "subscription_id" {
+  type = string
+  description = "The subscription id for where the storage account will be created"
+}
+variable "servicename" {
+  type        = string
+  description = "The name of your service"
+}
+variable "role" {
+  type        = string
+  description = "Role name but can be left as blank"
+}
+variable "deploy_environment" {
+  type = string
+  description = "THe envioronment for release e,g dev"
+}
+variable "resource_group_name" {
+  type = string
+  description = "The name of the resource group where the storage account will be created"
+}
+variable "resource_group_location" {
+  type = string
+  description = "Location of the resource group e.g UKSouth"
+}
+variable "account_kind" {
+  type = string
+  description = "Account kind e.g StorageV2"
+}
+variable "account_tier" {
+  type = string
+  description = "Account tier e.g Standard"
+}
+variable "account_replication_type" {
+  type = string
+  description = "Replication type e.g LRS"
+}
+variable "access_tier" {
+  type = string
+  description = "Access tier e.g Hot"
+}
+variable "https_traffic_only_enabled" {
+  type = bool
+  description = "Should be set as True"
+}
+variable "min_tls_version" {
+  type    = string
+  default = "TLS1_2"
+  description = "Minimium level should now be TLS1_2"
+}
+variable "subnet_ids" {
+  type    = list(string)
+  default = []
+  description = "A list of subnet resource ids, pass things like the AzDoPrd-vnet subnet reource id, can be 0 or many but atleast one subnet or ip must be set"
+}
+variable "allowed_ips" {
+  type    = list(string)
+  default = []
+  description = "A list of ip addresses, pass things like the the ukho site ip address, can be 0 or many but atleast one subnet or ip must be set"
+}
+
+```
+
+
+## Condition for subnets / ip addresses
+
+You must supply at least one subnet or one ip address when using this module, failure to do so with resort in a warning in the terraform plan.
+
+It is recommended that the AzDoPrd-vnet subnet resource id is passed as a minimium, buth more can be passed in the array if other connectivity is required.
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ variable "min_tls_version" {
 variable "subnet_ids" {
   type    = list(string)
   default = []
-  description = "A list of subnet resource ids, pass things like the AzDoPrd-vnet subnet reource id, can be 0 or many but atleast one subnet or ip must be set"
+  description = "A list of subnet resource ids, can be 0 or many but atleast one subnet or ip must be set"
 }
 variable "allowed_ips" {
   type    = list(string)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform Module: for Storage account with restricted public access
 
-This module can be used to create a storage account that is configured to restrict public 
+This module can be used to create a storage account that is configured to restrict public access.
 
 ## Required Resources
 

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,10 @@ terraform {
   }
 }
 
+provider "azurerm" {
+  features {}
+}
+
 locals {
   basename = lower("m${var.servicename}${var.role}${var.deploy_environment}sa")
 }

--- a/main.tf
+++ b/main.tf
@@ -37,5 +37,5 @@ resource "azurerm_storage_account_network_rules" "rules" {
   default_action             = "Deny"
   virtual_network_subnet_ids = var.subnet_ids
   bypass                     = ["AzureServices"]
-  ip_rules = [var.allowed_ips]
+  ip_rules                   = var.allowed_ips
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 provider "azurerm" {
   alias = "src"
+  features {}
 }
 
 locals {
@@ -22,4 +23,10 @@ resource "azurerm_storage_account" "logstashStorage" {
       tags
     ]
   }
+}
+
+resource "azurerm_storage_account_network_rules" "rules" {
+  storage_account_id = azurerm_storage_account.logstashStorage.id
+  default_action = "Deny"
+  virtual_network_subnet_ids = var.subnet_ids
 }

--- a/main.tf
+++ b/main.tf
@@ -39,4 +39,10 @@ resource "azurerm_storage_account_network_rules" "rules" {
   virtual_network_subnet_ids = var.subnet_ids
   bypass                     = ["AzureServices"]
   ip_rules                   = var.allowed_ips
+  lifecycle {
+    precondition {
+      condition     = length(var.subnet_ids) + length(var.allowed_ips) != 0
+      error_message = "Using this module requires the subnet_ids or the allowed_ips array to contain at least one value."
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,22 +1,25 @@
 provider "azurerm" {
-  alias = "src"
-  features {}
+  alias           = "src"
+  subscription_id = var.subscription_id
+  features {
+
+  }
 }
 
 locals {
   basename = lower("m${var.servicename}${var.role}${var.deploy_environment}")
 }
 
-resource "azurerm_storage_account" "logstashStorage" {
-  provider = azurerm.src
-  name                      = local.basename
-  resource_group_name       = var.resource_group_name
-  location                  = var.resource_group_location
-  account_kind              = var.account_kind
-  account_tier              = var.account_tier
-  account_replication_type  = var.account_replication_type
-  access_tier               = var.access_tier
-  enable_https_traffic_only = var.enable_https_traffic_only
+resource "azurerm_storage_account" "sa" {
+  provider                   = azurerm.src
+  name                       = local.basename
+  resource_group_name        = var.resource_group_name
+  location                   = var.resource_group_location
+  account_kind               = var.account_kind
+  account_tier               = var.account_tier
+  account_replication_type   = var.account_replication_type
+  access_tier                = var.access_tier
+  https_traffic_only_enabled = var.https_traffic_only_enabled
 
   lifecycle {
     ignore_changes = [
@@ -26,7 +29,7 @@ resource "azurerm_storage_account" "logstashStorage" {
 }
 
 resource "azurerm_storage_account_network_rules" "rules" {
-  storage_account_id = azurerm_storage_account.logstashStorage.id
-  default_action = "Deny"
+  storage_account_id         = azurerm_storage_account.sa.id
+  default_action             = "Deny"
   virtual_network_subnet_ids = var.subnet_ids
 }

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,16 @@
-provider "azurerm" {
-  alias           = "src"
-  subscription_id = var.subscription_id
-  features {
-
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      configuration_aliases = [
+        azurerm.src
+      ]
+    }
   }
 }
 
 locals {
-  basename = lower("m${var.servicename}${var.deploy_environment}sa")
+  basename = lower("m${var.servicename}${var.role}${var.deploy_environment}sa")
 }
 
 resource "azurerm_storage_account" "sa" {
@@ -34,4 +37,5 @@ resource "azurerm_storage_account_network_rules" "rules" {
   default_action             = "Deny"
   virtual_network_subnet_ids = var.subnet_ids
   bypass                     = ["AzureServices"]
+  ip_rules = [var.allowed_ips]
 }

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ resource "azurerm_storage_account" "sa" {
 }
 
 resource "azurerm_storage_account_network_rules" "rules" {
+  provider                   = azurerm.src
   storage_account_id         = azurerm_storage_account.sa.id
   default_action             = "Deny"
   virtual_network_subnet_ids = var.subnet_ids

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ provider "azurerm" {
 }
 
 locals {
-  basename = lower("m${var.servicename}${var.role}${var.deploy_environment}")
+  basename = lower("m${var.servicename}${var.deploy_environment}sa")
 }
 
 resource "azurerm_storage_account" "sa" {

--- a/main.tf
+++ b/main.tf
@@ -9,10 +9,6 @@ terraform {
   }
 }
 
-provider "azurerm" {
-  features {}
-}
-
 locals {
   basename = lower("m${var.servicename}${var.role}${var.deploy_environment}sa")
 }

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ resource "azurerm_storage_account" "sa" {
   account_tier               = var.account_tier
   account_replication_type   = var.account_replication_type
   access_tier                = var.access_tier
+  min_tls_version            = var.min_tls_version
   https_traffic_only_enabled = var.https_traffic_only_enabled
 
   lifecycle {
@@ -32,4 +33,5 @@ resource "azurerm_storage_account_network_rules" "rules" {
   storage_account_id         = azurerm_storage_account.sa.id
   default_action             = "Deny"
   virtual_network_subnet_ids = var.subnet_ids
+  bypass                     = ["AzureServices"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -34,10 +34,12 @@ variable "min_tls_version" {
 }
 variable "subnet_ids" {
   type = list(string)
+   default = []
 }
 variable "subscription_id" {
   type = string
 }
 variable "allowed_ips" {
   type = list(string)
+  default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "min_tls_version" {
 variable "subnet_ids" {
   type    = list(string)
   default = []
-  description = "A list of subnet resource ids, pass things like the AzDoPrd-vnet subnet reource id, can be 0 or many but atleast one subnet or ip must be set"
+  description = "A list of subnet resource ids, can be 0 or many but atleast one subnet or ip must be set"
 }
 variable "allowed_ips" {
   type    = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -1,45 +1,59 @@
-variable "servicename" {
+variable "subscription_id" {
   type = string
+  description = "The subscription id for where the storage account will be created"
+}
+variable "servicename" {
+  type        = string
+  description = "The name of your service"
 }
 variable "role" {
-  type = string
+  type        = string
+  description = "Role name but can be left as blank"
 }
 variable "deploy_environment" {
   type = string
+  description = "THe envioronment for release e,g dev"
 }
 variable "resource_group_name" {
   type = string
+  description = "The name of the resource group where the storage account will be created"
 }
 variable "resource_group_location" {
   type = string
+  description = "Location of the resource group e.g UKSouth"
 }
 variable "account_kind" {
   type = string
+  description = "Account kind e.g StorageV2"
 }
 variable "account_tier" {
   type = string
+  description = "Account tier e.g Standard"
 }
 variable "account_replication_type" {
   type = string
+  description = "Replication type e.g LRS"
 }
 variable "access_tier" {
   type = string
+  description = "Access tier e.g Hot"
 }
 variable "https_traffic_only_enabled" {
   type = bool
+  description = "Should be set as True"
 }
 variable "min_tls_version" {
-  type = string
+  type    = string
   default = "TLS1_2"
+  description = "Minimium level should now be TLS1_2"
 }
 variable "subnet_ids" {
-  type = list(string)
-   default = []
-}
-variable "subscription_id" {
-  type = string
+  type    = list(string)
+  default = []
+  description = "A list of subnet resource ids, pass things like the AzDoPrd-vnet subnet reource id, can be 0 or many but atleast one subnet or ip must be set"
 }
 variable "allowed_ips" {
-  type = list(string)
+  type    = list(string)
   default = []
+  description = "A list of ip addresses, pass things like the the ukho site ip address, can be 0 or many but atleast one subnet or ip must be set"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,10 @@ variable "access_tier" {
 variable "https_traffic_only_enabled" {
   type = bool
 }
+variable "min_tls_version" {
+  type = string
+  default = "TLS1_2"
+}
 variable "subnet_ids" {
   type = list(string)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,9 +4,6 @@ variable "servicename" {
 variable "deploy_environment" {
   type = string
 }
-variable "role" {
-  type = string
-}
 variable "resource_group_name" {
   type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,9 +25,12 @@ variable "account_replication_type" {
 variable "access_tier" {
   type = string
 }
-variable "enable_https_traffic_only" {
+variable "https_traffic_only_enabled" {
   type = bool
 }
 variable "subnet_ids" {
   type = list(string)
+}
+variable "subscription_id" {
+  type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -28,3 +28,6 @@ variable "access_tier" {
 variable "enable_https_traffic_only" {
   type = bool
 }
+variable "subnet_ids" {
+  type = list(string)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,9 @@
 variable "servicename" {
   type = string
 }
+variable "role" {
+  type = string
+}
 variable "deploy_environment" {
   type = string
 }
@@ -34,4 +37,7 @@ variable "subnet_ids" {
 }
 variable "subscription_id" {
   type = string
+}
+variable "allowed_ips" {
+  type = list(string)
 }


### PR DESCRIPTION
Modifications to original release

Allow azure services to connect
TLS set to 1.2 but can be passed in if higher needed in future

Security
Allow subnet resource ids to be passed in
Allow ip addresses to be passed in

One of the above must be present for module to work, plan will fail with a warning if none are set.